### PR TITLE
Pin PyPI version from release tag

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       id-token: write
     env:
-      TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
+      TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -37,21 +37,21 @@ jobs:
         working-directory: python
         run: python -m pip install build
 
-      # - name: Resolve PyPI version
-      #   id: pypi-version
-      #   run: |
-      #     PYPI_VERSION="$(python - <<'PY'
-      #     import os
-      #     from packaging.version import Version
+      - name: Resolve PyPI version
+        id: pypi-version
+        run: |
+          PYPI_VERSION="$(python - <<'PY'
+          import os
+          from packaging.version import Version
 
-      #     tag = os.environ["TAG"]
-      #     if tag.startswith("v"):
-      #       tag = tag[1:]
-      #     print(Version(tag))
-      #     PY
-      #     )"
-      #     echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ATLASSIAN_GEN_CLIENT=${PYPI_VERSION}" >> "$GITHUB_ENV"
-      #     echo "version=${PYPI_VERSION}" >> "$GITHUB_OUTPUT"
+          tag = os.environ["TAG"]
+          if tag.startswith("v"):
+            tag = tag[1:]
+          print(Version(tag))
+          PY
+          )"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ATLASSIAN_GEN_CLIENT=${PYPI_VERSION}" >> "$GITHUB_ENV"
+          echo "version=${PYPI_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         working-directory: python


### PR DESCRIPTION
## Summary
- set PyPI version from release tag in publish workflow
- normalize tags to PEP 440 for PyPI upload

## Testing
- not run (workflow-only change)